### PR TITLE
UnixFS, some missing commands, gofumpt

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,4 +1,4 @@
-package memfs
+package backend
 
 import (
 	"github.com/smallfz/libnfs-go/fs"
@@ -22,9 +22,6 @@ func (s *backendSession) GetFS() fs.FS {
 }
 
 func (s *backendSession) GetStatService() nfs.StatService {
-	if s.stat == nil {
-		s.stat = &Stat{}
-	}
 	return s.stat
 }
 
@@ -32,11 +29,11 @@ type Backend struct {
 	vfs fs.FS
 }
 
-// NewBackend creates a new Backend instalce.
-func NewBackend(vfs fs.FS) *Backend {
+// New creates a new Backend instance.
+func New(vfs fs.FS) *Backend {
 	return &Backend{vfs: vfs}
 }
 
 func (b *Backend) CreateSession(state nfs.SessionState) nfs.BackendSession {
-	return &backendSession{vfs: b.vfs}
+	return &backendSession{vfs: b.vfs, stat: new(Stat)}
 }

--- a/examples/proxy/main.go
+++ b/examples/proxy/main.go
@@ -6,13 +6,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"sync"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
 	"github.com/smallfz/libnfs-go/nfs/implv4"
 	"github.com/smallfz/libnfs-go/xdr"
-	"io"
-	"net"
-	"sync"
 )
 
 const (
@@ -454,8 +455,6 @@ func proxyStream(s *Session, tag string, ctx context.Context, src io.Reader, dst
 			return fmt.Errorf("writer.Write(%d bytes): %v", len(reqRawb), err)
 		}
 	}
-
-	return nil
 }
 
 func handleSession(ctx context.Context, conn net.Conn) error {
@@ -515,5 +514,4 @@ func main() {
 			}()
 		}
 	}
-
 }

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -3,35 +3,37 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
+	"github.com/smallfz/libnfs-go/backend"
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/memfs"
 	"github.com/smallfz/libnfs-go/server"
-	"os"
 )
 
 func main() {
 	defer log.Sync()
 
-	port := 2049
-	flag.IntVar(&port, "p", port, "serving port.")
+	listen := ":2049"
+	flag.StringVar(&listen, "l", listen, "Server listen address")
 	flag.Parse()
 
 	log.UpdateLevel(log.DEBUG)
 
 	mfs := memfs.NewMemFS()
-	backend := memfs.NewBackend(mfs)
+	backend := backend.New(mfs)
 
-	mfs.MkdirAll("/mount", os.FileMode(0755))
-	mfs.MkdirAll("/test", os.FileMode(0755))
-	mfs.MkdirAll("/test2", os.FileMode(0755))
-	mfs.MkdirAll("/many", os.FileMode(0755))
+	mfs.MkdirAll("/mount", os.FileMode(0o755))
+	mfs.MkdirAll("/test", os.FileMode(0o755))
+	mfs.MkdirAll("/test2", os.FileMode(0o755))
+	mfs.MkdirAll("/many", os.FileMode(0o755))
 
-	perm := os.FileMode(0755)
+	perm := os.FileMode(0o755)
 	for i := 0; i < 256; i++ {
 		mfs.MkdirAll(fmt.Sprintf("/many/sub-%d", i+1), perm)
 	}
 
-	svr, err := server.NewServerTCP(port, backend)
+	svr, err := server.NewServerTCP(listen, backend)
 	if err != nil {
 		log.Errorf("server.NewServerTCP: %v", err)
 		return

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -34,6 +34,10 @@ type FS interface {
 	OpenFile(string, int, os.FileMode) (File, error)
 	Stat(string) (FileInfo, error)
 	Chmod(string, os.FileMode) error
+	Chown(string, int, int) error
+	Symlink(string, string) error
+	Readlink(string) (string, error)
+	Link(string, string) error
 	Rename(string, string) error
 	Remove(string) error
 	MkdirAll(string, os.FileMode) error
@@ -49,6 +53,9 @@ type FS interface {
 
 	// ResolveHandle translate the giving handle to full path of the corresponding file.
 	ResolveHandle([]byte) (string, error)
+
+	// Attributes returns the FS' attributes that can be edited.
+	Attributes() *Attributes
 }
 
 type FSWithId interface {
@@ -59,4 +66,13 @@ type FSWithId interface {
 type AllowLink interface {
 	Lstat(string) (FileInfo, error)
 	Symlink(string, string) error
+}
+
+// https://datatracker.ietf.org/doc/html/rfc7530#section-5.6
+type Attributes struct {
+	LinkSupport     bool   // id: 5
+	SymlinkSupport  bool   // id: 6
+	ChownRestricted bool   // id: 18
+	MaxName         uint32 // id: 29
+	NoTrunc         bool   // id: 34
 }

--- a/fs/path_test.go
+++ b/fs/path_test.go
@@ -6,17 +6,17 @@ import (
 
 func TestAbs(t *testing.T) {
 	grantedCases := [][]string{
-		[]string{"", "/"},
-		[]string{".", "/"},
-		[]string{"/", "/"},
-		[]string{"a/bc/def", "/a/bc/def"},
-		[]string{"/a/bc", "/a/bc"},
-		[]string{"abc", "/abc"},
-		[]string{"./abc", "/abc"},
-		[]string{"../abc", "/abc"},
-		[]string{"/../abc", "/abc"},
-		[]string{"./../abc", "/abc"},
-		[]string{"./../abc/def", "/abc/def"},
+		{"", "/"},
+		{".", "/"},
+		{"/", "/"},
+		{"a/bc/def", "/a/bc/def"},
+		{"/a/bc", "/a/bc"},
+		{"abc", "/abc"},
+		{"./abc", "/abc"},
+		{"../abc", "/abc"},
+		{"/../abc", "/abc"},
+		{"./../abc", "/abc"},
+		{"./../abc/def", "/abc/def"},
 	}
 
 	for _, row := range grantedCases {
@@ -30,11 +30,11 @@ func TestAbs(t *testing.T) {
 
 func TestPathJoin(t *testing.T) {
 	grantedCases := [][]string{
-		[]string{"", "/", "/"},
-		[]string{"abc", "/def", "/abc/def"},
-		[]string{"/abc", "/def", "/abc/def"},
-		[]string{"/abc", "def", "/abc/def"},
-		[]string{"/abc", "def", "/ijk", "/abc/def/ijk"},
+		{"", "/", "/"},
+		{"abc", "/def", "/abc/def"},
+		{"/abc", "/def", "/abc/def"},
+		{"/abc", "def", "/abc/def"},
+		{"/abc", "def", "/ijk", "/abc/def/ijk"},
 	}
 
 	for _, row := range grantedCases {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/smallfz/libnfs-go
 
 go 1.16
 
-require (
-	github.com/rs/zerolog v1.26.0
-)
+require github.com/rs/zerolog v1.26.0

--- a/log/log.go
+++ b/log/log.go
@@ -2,10 +2,11 @@ package log
 
 import (
 	"fmt"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"os"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 const (

--- a/memfs/buffer.go
+++ b/memfs/buffer.go
@@ -1,7 +1,7 @@
 package memfs
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -83,7 +83,7 @@ func (b *Buffer) Seek(offset int64, whence int) (int64, error) {
 	}
 
 	if cur < 0 {
-		return int64(b.cur), fmt.Errorf("invalid seeking position.")
+		return int64(b.cur), errors.New("invalid seeking position")
 	}
 
 	b.cur = cur

--- a/memfs/buffer_test.go
+++ b/memfs/buffer_test.go
@@ -82,16 +82,16 @@ type writingBlock struct {
 
 func TestBufferSeekingMultipleTimes(t *testing.T) {
 	blocks := []*writingBlock{
-		&writingBlock{offset: 0, data: []byte("0123")},
-		&writingBlock{offset: 4, data: []byte("4567")},
-		&writingBlock{offset: 8, data: []byte("89ab")},
-		&writingBlock{offset: 12, data: []byte("cdef")},
-		&writingBlock{offset: 16, data: []byte("____")},
-		&writingBlock{offset: 20, data: []byte("AAA")},
+		{offset: 0, data: []byte("0123")},
+		{offset: 4, data: []byte("4567")},
+		{offset: 8, data: []byte("89ab")},
+		{offset: 12, data: []byte("cdef")},
+		{offset: 16, data: []byte("____")},
+		{offset: 20, data: []byte("AAA")},
 	}
 
 	index := make([]int, len(blocks))
-	for i, _ := range index {
+	for i := range index {
 		index[i] = i
 	}
 

--- a/memfs/file.go
+++ b/memfs/file.go
@@ -2,9 +2,10 @@ package memfs
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/smallfz/libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/log"
-	"io"
 )
 
 type closeHandler func(bool, []byte)

--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -4,13 +4,14 @@ package memfs
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/smallfz/libnfs-go/fs"
-	"github.com/smallfz/libnfs-go/log"
 	"io"
 	"os"
 	"path"
 	"sync"
 	"time"
+
+	"github.com/smallfz/libnfs-go/fs"
+	"github.com/smallfz/libnfs-go/log"
 )
 
 const (
@@ -113,8 +114,9 @@ func (n *memFsNode) removeChild(name string) (*memFsNode, bool) {
 // -----
 
 type MemFS struct {
-	store fs.Storage
-	root  *memFsNode
+	store      fs.Storage
+	root       *memFsNode
+	attributes fs.Attributes
 
 	fileId uint64
 	lck    *sync.RWMutex
@@ -129,9 +131,16 @@ func NewMemFS() *MemFS {
 			id:    1000,
 			name:  "",
 			isDir: true,
-			perm:  os.FileMode(0755),
+			perm:  os.FileMode(0o755),
 			cTime: time.Now(),
 			mTime: time.Now(),
+		},
+		attributes: fs.Attributes{
+			LinkSupport:     true,
+			SymlinkSupport:  false, // unsopported
+			ChownRestricted: true,  // unsopported
+			MaxName:         255,   // common value
+			NoTrunc:         false,
 		},
 	}
 }
@@ -209,7 +218,7 @@ func (s *MemFS) writeNode(n *memFsNode, dat []byte) {
 }
 
 func (s *MemFS) Open(name string) (fs.File, error) {
-	return s.OpenFile(name, os.O_RDONLY, os.FileMode(0644))
+	return s.OpenFile(name, os.O_RDONLY, os.FileMode(0o644))
 }
 
 func (s *MemFS) OpenFile(name string, flag int, perm os.FileMode) (fs.File, error) {
@@ -289,7 +298,6 @@ func (s *MemFS) OpenFile(name string, flag int, perm os.FileMode) (fs.File, erro
 		// log.Printf("MemFS.OpenFile: writing %d bytes.", len(dat))
 		s.writeNode(n, dat)
 	}), nil
-
 }
 
 func (s *MemFS) Stat(name string) (fs.FileInfo, error) {
@@ -462,4 +470,28 @@ func (s *MemFS) ResolveHandle(fh []byte) (string, error) {
 	}
 
 	return fs.Abs(fs.Join(parts...)), nil
+}
+
+func (s *MemFS) Chown(name string, uid, gid int) error {
+	log.Warn("TODO: memfs.Chown not implemented")
+	return nil
+}
+
+func (s *MemFS) Link(oldName, newName string) error {
+	log.Warn("TODO: memfs.Link not implemented")
+	return nil
+}
+
+func (s *MemFS) Symlink(oldName, newName string) error {
+	log.Warn("TODO: memfs.Symlink not implemented")
+	return nil
+}
+
+func (s *MemFS) Readlink(name string) (string, error) {
+	log.Warn("TODO: memfs.Readlink not implemented")
+	return name, nil
+}
+
+func (s *MemFS) Attributes() *fs.Attributes {
+	return &s.attributes
 }

--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -2,9 +2,10 @@ package memfs
 
 import (
 	"bytes"
-	"github.com/smallfz/libnfs-go/fs"
 	"io"
 	"sync"
+
+	"github.com/smallfz/libnfs-go/fs"
 )
 
 type dataNode struct {

--- a/nfs/backend.go
+++ b/nfs/backend.go
@@ -1,8 +1,9 @@
 package nfs
 
 import (
-	"github.com/smallfz/libnfs-go/fs"
 	"net"
+
+	"github.com/smallfz/libnfs-go/fs"
 )
 
 // SessionState represents a client network session.
@@ -19,6 +20,7 @@ type StatService interface {
 	CurrentHandle() FileHandle4
 
 	PushHandle(FileHandle4)
+	PeekHandle() (FileHandle4, bool)
 	PopHandle() (FileHandle4, bool)
 
 	SetClientId(uint64)
@@ -39,7 +41,6 @@ type StatService interface {
 
 // BackendSession has a lifetime exact as the client connection.
 type BackendSession interface {
-
 	// GetFS should return a FS implementation.
 	GetFS() fs.FS
 

--- a/nfs/bitmap4.go
+++ b/nfs/bitmap4.go
@@ -2,7 +2,7 @@ package nfs
 
 func Bitmap4Encode(x map[int]bool) []uint32 {
 	max := 0
-	for v, _ := range x {
+	for v := range x {
 		if v > max {
 			max = v
 		}

--- a/nfs/implv3/getattr.go
+++ b/nfs/implv3/getattr.go
@@ -12,23 +12,22 @@ import (
 //
 // SYNOPSIS
 //
-//     GETATTR3res NFSPROC3_GETATTR(GETATTR3args) = 1;
+//	GETATTR3res NFSPROC3_GETATTR(GETATTR3args) = 1;
 //
-//     struct GETATTR3args {
-//        nfs_fh3  object;
-//     };
+//	struct GETATTR3args {
+//	   nfs_fh3  object;
+//	};
 //
-//     struct GETATTR3resok {
-//        fattr3   obj_attributes;
-//     };
+//	struct GETATTR3resok {
+//	   fattr3   obj_attributes;
+//	};
 //
-//     union GETATTR3res switch (nfsstat3 status) {
-//     case NFS3_OK:
-//        GETATTR3resok  resok;
-//     default:
-//        void;
-//     };
-//
+//	union GETATTR3res switch (nfsstat3 status) {
+//	case NFS3_OK:
+//	   GETATTR3resok  resok;
+//	default:
+//	   void;
+//	};
 func GetAttr(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 	r, w := ctx.Reader(), ctx.Writer()
 

--- a/nfs/implv4/access.go
+++ b/nfs/implv4/access.go
@@ -1,9 +1,10 @@
 package implv4
 
 import (
+	"os"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"os"
 )
 
 func computeAccessOnFile(mode os.FileMode, access uint32) (uint32, uint32) {

--- a/nfs/implv4/access_test.go
+++ b/nfs/implv4/access_test.go
@@ -1,13 +1,14 @@
 package implv4
 
 import (
-	"github.com/smallfz/libnfs-go/nfs"
 	"os"
 	"testing"
+
+	"github.com/smallfz/libnfs-go/nfs"
 )
 
 func TestAccess_file_0555_w(t *testing.T) {
-	mode := os.FileMode(0555)
+	mode := os.FileMode(0o555)
 	access := nfs.ACCESS4_MODIFY
 
 	support, accForFh := computeAccessOnFile(mode, access)

--- a/nfs/implv4/bitmap4.go
+++ b/nfs/implv4/bitmap4.go
@@ -2,7 +2,7 @@ package implv4
 
 func bitmap4Encode(x map[int]bool) []uint32 {
 	max := 0
-	for v, _ := range x {
+	for v := range x {
 		if v > max {
 			max = v
 		}

--- a/nfs/implv4/compound.go
+++ b/nfs/implv4/compound.go
@@ -2,7 +2,7 @@ package implv4
 
 import (
 	"io"
-	// "libnfs-go/fs"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
 )
@@ -89,7 +89,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_SETCLIENTID_CONFIRM:
 			args := &nfs.SETCLIENTID_CONFIRM4args{}
@@ -105,7 +104,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_EXCHANGE_ID:
 			args := &nfs.EXCHANGE_ID4args{}
@@ -131,7 +129,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_PUTROOTFH:
 			// reset cwd to /
@@ -147,7 +144,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_GETATTR:
 			args := &nfs.GETATTR4args{}
@@ -165,7 +161,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_PUTFH:
 			args := &nfs.PUTFH4args{}
@@ -196,7 +191,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_GETFH:
 			stat := ctx.Stat()
@@ -228,7 +222,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_LOOKUP:
 			args := &nfs.LOOKUP4args{}
@@ -247,7 +240,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_ACCESS:
 			args := &nfs.ACCESS4args{}
@@ -266,7 +258,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_READDIR:
 			args := &nfs.READDIR4args{}
@@ -285,7 +276,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_SECINFO:
 			args := &nfs.SECINFO4args{}
@@ -300,7 +290,7 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 				Status: nfs.NFS4_OK,
 				Ok: &nfs.SECINFO4resok{
 					Items: []*nfs.Secinfo4{
-						&nfs.Secinfo4{
+						{
 							Flavor: 0,
 							FlavorInfo: &nfs.RPCSecGssInfo{
 								Service: nfs.RPC_GSS_SVC_NONE,
@@ -313,7 +303,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_RENEW:
 			args := &nfs.RENEW4args{}
@@ -331,16 +320,14 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_CREATE:
 			// rfc7530, 16.4.2
 			args, size, err := readOpCreateArgs(r)
 			if err != nil {
 				return sizeConsumed, err
-			} else {
-				sizeConsumed += size
 			}
+			sizeConsumed += size
 
 			res, err := create(ctx, args)
 			if err != nil {
@@ -350,15 +337,13 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_OPEN:
 			args, size, err := readOpOpenArgs(r)
 			if err != nil {
 				return sizeConsumed, err
-			} else {
-				sizeConsumed += size
 			}
+			sizeConsumed += size
 
 			res, err := open(ctx, args)
 			if err != nil {
@@ -368,15 +353,13 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_OPEN_DOWNGRADE:
 			args, size, err := readOpOpenDgArgs(r)
 			if err != nil {
 				return sizeConsumed, err
-			} else {
-				sizeConsumed += size
 			}
+			sizeConsumed += size
 
 			res, err := openDg(ctx, args)
 			if err != nil {
@@ -386,7 +369,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_CLOSE:
 			args := &nfs.CLOSE4args{}
@@ -404,7 +386,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_SETATTR:
 			args := &nfs.SETATTR4args{}
@@ -422,7 +403,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_REMOVE:
 			args := &nfs.REMOVE4args{}
@@ -440,7 +420,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_COMMIT:
 			args := &nfs.COMMIT4args{}
@@ -458,7 +437,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_WRITE:
 			args := &nfs.WRITE4args{}
@@ -476,7 +454,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_READ:
 			args := &nfs.READ4args{}
@@ -494,7 +471,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_SAVEFH:
 			st := ctx.Stat()
@@ -506,7 +482,6 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
 
 		case nfs.OP4_RESTOREFH:
 			st := ctx.Stat()
@@ -522,7 +497,50 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 			rsOpList = append(rsOpList, opnum4)
 			rsStatusList = append(rsStatusList, res.Status)
 			rsList = append(rsList, res)
-			break
+
+		case nfs.OP4_RENAME:
+			var args nfs.RENAME4args
+			size, err := r.ReadAs(&args)
+			if err != nil {
+				return sizeConsumed, err
+			}
+			sizeConsumed += size
+
+			res, err := rename(ctx, &args)
+			if err != nil {
+				return sizeConsumed, err
+			}
+
+			rsOpList = append(rsOpList, opnum4)
+			rsStatusList = append(rsStatusList, res.Status)
+			rsList = append(rsList, res)
+
+		case nfs.OP4_LINK:
+			var args nfs.LINK4args
+			size, err := r.ReadAs(&args)
+			if err != nil {
+				return sizeConsumed, err
+			}
+			sizeConsumed += size
+
+			res, err := link(ctx, &args)
+			if err != nil {
+				return sizeConsumed, err
+			}
+
+			rsOpList = append(rsOpList, opnum4)
+			rsStatusList = append(rsStatusList, res.Status)
+			rsList = append(rsList, res)
+
+		case nfs.OP4_READLINK:
+			res, err := readlink(ctx)
+			if err != nil {
+				return sizeConsumed, err
+			}
+
+			rsOpList = append(rsOpList, opnum4)
+			rsStatusList = append(rsStatusList, res.Status)
+			rsList = append(rsList, res)
 
 		default:
 			log.Warnf("op not handled: %d.", opnum4)
@@ -553,11 +571,9 @@ func Compound(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 					log.Errorf("Compound(): io.Copy: %v", err)
 				}
 			}
-			break
 
 		default:
 			w.WriteAny(rs)
-			break
 		}
 	}
 

--- a/nfs/implv4/compound_test.go
+++ b/nfs/implv4/compound_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"testing"
+
 	"github.com/smallfz/libnfs-go/nfs"
 	"github.com/smallfz/libnfs-go/xdr"
-	"testing"
 )
 
 /*
@@ -184,7 +185,6 @@ func TestParsingCOMPOUND4_res_putfh_readdir(t *testing.T) {
 			return
 		}
 	}
-
 }
 
 func TestParsingCOMPOUND4_res_getAttr(t *testing.T) {
@@ -313,5 +313,4 @@ func TestParsingCOMPOUND4_res_getAttr(t *testing.T) {
 			return
 		}
 	}
-
 }

--- a/nfs/implv4/getattr.go
+++ b/nfs/implv4/getattr.go
@@ -1,11 +1,8 @@
 package implv4
 
 import (
-	// "bytes"
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	// "libnfs-go/xdr"
-	// "encoding/base64"
 )
 
 func getAttr(x nfs.RPCContext, args *nfs.GETATTR4args) (*nfs.GETATTR4res, error) {

--- a/nfs/implv4/link.go
+++ b/nfs/implv4/link.go
@@ -1,0 +1,78 @@
+package implv4
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/smallfz/libnfs-go/log"
+	"github.com/smallfz/libnfs-go/nfs"
+)
+
+func link(x nfs.RPCContext, args *nfs.LINK4args) (*nfs.LINK4res, error) {
+	log.Debugf("link obj: %s", strconv.Quote(args.NewName))
+
+	stat := x.Stat()
+	vfs := x.GetFS()
+
+	//
+	// Check source stored by previous SAVE_FH call.
+	//
+	savefh, ok := stat.PeekHandle()
+	if !ok {
+		log.Warn("PopHandle: SAVED_FH not found")
+		return &nfs.LINK4res{Status: nfs.NFS4ERR_INVAL}, nil
+	}
+
+	oldpath, err := vfs.ResolveHandle(savefh)
+	if err != nil {
+		log.Warnf("ResolveHandle: %v", err)
+		return &nfs.LINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	_, err = vfs.Stat(oldpath)
+	if err != nil {
+		log.Warnf("  link: vfs.Stat(%s): %v", oldpath, err)
+		return &nfs.LINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	//
+	// Check destination.
+	//
+	fh := stat.CurrentHandle()
+	folder, err := vfs.ResolveHandle(fh)
+	if err != nil {
+		log.Warnf("ResolveHandle: %v", err)
+		return &nfs.LINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	newpath := path.Join(folder, args.NewName)
+	_, err = vfs.Stat(newpath)
+	if err == nil || os.IsExist(err) {
+		if err == nil {
+			err = fs.ErrExist
+		}
+		log.Warnf("  link: exists: vfs.Stat(%s): %v", newpath, err)
+		return &nfs.LINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	//
+	// Perform Link.
+	//
+	if err := vfs.Link(oldpath, newpath); err != nil {
+		log.Warnf("link: vfs.Link(%s, %s): %v", oldpath, newpath, err)
+		return &nfs.LINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	return &nfs.LINK4res{
+		Status: nfs.NFS4_OK,
+		Ok: &nfs.LINK4resok{
+			CInfo: &nfs.ChangeInfo4{
+				Atomic: true,
+				Before: 0,
+				After:  0,
+			},
+		},
+	}, nil
+}

--- a/nfs/implv4/open_downgrade.go
+++ b/nfs/implv4/open_downgrade.go
@@ -1,13 +1,9 @@
 package implv4
 
 import (
-	// "bytes"
-	// "fmt"
-	// "libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
 	"github.com/smallfz/libnfs-go/xdr"
-	// "os"
 )
 
 func readOpOpenDgArgs(r *xdr.Reader) (*nfs.OPENDG4args, int, error) {

--- a/nfs/implv4/read.go
+++ b/nfs/implv4/read.go
@@ -2,13 +2,13 @@ package implv4
 
 import (
 	"bytes"
+	"io"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"io"
 )
 
 func read(x nfs.RPCContext, args *nfs.READ4args) (*nfs.READ4res, error) {
-
 	// stat := x.Stat()
 	// vfs := x.GetFS()
 

--- a/nfs/implv4/readdir.go
+++ b/nfs/implv4/readdir.go
@@ -2,12 +2,11 @@ package implv4
 
 import (
 	"bytes"
+
 	"github.com/smallfz/libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
 	"github.com/smallfz/libnfs-go/xdr"
-	// "path"
-	// "encoding/json"
 )
 
 func encodeReaddirResult(res *nfs.READDIR4res) *nfs.ResGenericRaw {

--- a/nfs/implv4/readlink.go
+++ b/nfs/implv4/readlink.go
@@ -1,0 +1,35 @@
+package implv4
+
+import (
+	"github.com/smallfz/libnfs-go/log"
+	"github.com/smallfz/libnfs-go/nfs"
+)
+
+func readlink(x nfs.RPCContext) (*nfs.READLINK4res, error) {
+	stat := x.Stat()
+	vfs := x.GetFS()
+
+	name, err := vfs.ResolveHandle(stat.CurrentHandle())
+	if err != nil {
+		log.Warnf("vfs.ResolveHandle: %v", err)
+		return &nfs.READLINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	_, err = vfs.Stat(name)
+	if err != nil {
+		log.Warnf("  remove: vfs.Stat(%s): %v", name, err)
+	}
+
+	link, err := vfs.Readlink(name)
+	if err != nil {
+		log.Warnf("remove: vfs.Readlink(%s): %v", name, err)
+		return &nfs.READLINK4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	return &nfs.READLINK4res{
+		Status: nfs.NFS4_OK,
+		Ok: &nfs.READLINK4resok{
+			Link: link,
+		},
+	}, nil
+}

--- a/nfs/implv4/rename.go
+++ b/nfs/implv4/rename.go
@@ -1,0 +1,76 @@
+package implv4
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/smallfz/libnfs-go/log"
+	"github.com/smallfz/libnfs-go/nfs"
+)
+
+func rename(x nfs.RPCContext, args *nfs.RENAME4args) (*nfs.RENAME4res, error) {
+	log.Debugf("remame obj: %s -> %s", strconv.Quote(args.OldName), strconv.Quote(args.NewName))
+
+	stat := x.Stat()
+	vfs := x.GetFS()
+
+	fh := stat.CurrentHandle()
+
+	//
+	// Check source.
+	//
+	folder, err := vfs.ResolveHandle(fh)
+	if err != nil {
+		log.Warnf("ResolveHandle: %v", err)
+		return &nfs.RENAME4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	oldpath := path.Join(folder, args.OldName)
+	_, err = vfs.Stat(oldpath)
+	if err != nil {
+		log.Warnf("  rename: vfs.Stat(%s): %v", oldpath, err)
+		return &nfs.RENAME4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	//
+	// Check destination.
+	//
+	newpath := path.Join(folder, args.NewName)
+	fi, err := vfs.Stat(newpath)
+	if err == nil && fi.Mode().Type() != os.ModeSymlink {
+		// According to NFStest (nfstest_posix),
+		// nfsv4 can remane a file to an existing symlink so we should not return an error in this case.
+		err = fs.ErrExist
+	}
+	if err != nil && !os.IsNotExist(err) {
+		log.Warnf("  rename: vfs.Stat(%s): %v", newpath, err)
+		return &nfs.RENAME4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	//
+	// Perform Rename.
+	//
+	if err := vfs.Rename(oldpath, newpath); err != nil {
+		log.Warnf("rename: vfs.Rename(%s, %s): %v", oldpath, newpath, err)
+		return &nfs.RENAME4res{Status: nfs.NFS4err(err)}, nil
+	}
+
+	res := &nfs.RENAME4res{
+		Status: nfs.NFS4_OK,
+		Ok: &nfs.RENAME4resok{
+			SourceCInfo: &nfs.ChangeInfo4{
+				Atomic: true,
+				Before: 0,
+				After:  0,
+			},
+			TargetCInfo: &nfs.ChangeInfo4{
+				Atomic: true,
+				Before: 0,
+				After:  0,
+			},
+		},
+	}
+	return res, nil
+}

--- a/nfs/implv4/setclientid_test.go
+++ b/nfs/implv4/setclientid_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"testing"
+
 	"github.com/smallfz/libnfs-go/nfs"
 	"github.com/smallfz/libnfs-go/xdr"
-	"testing"
 )
 
 func TestParsingSETCLIENTID4_res(t *testing.T) {
@@ -75,5 +76,4 @@ func TestParsingSETCLIENTID4_res(t *testing.T) {
 	}
 
 	fmt.Println(toJson(res))
-
 }

--- a/nfs/implv4/void.go
+++ b/nfs/implv4/void.go
@@ -1,7 +1,6 @@
 package implv4
 
 import (
-	// "libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
 )
 

--- a/nfs/implv4/write.go
+++ b/nfs/implv4/write.go
@@ -2,14 +2,13 @@ package implv4
 
 import (
 	"bytes"
+	"io"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"io"
-	// "os"
 )
 
 func write(x nfs.RPCContext, args *nfs.WRITE4args) (*nfs.WRITE4res, error) {
-
 	// stat := x.Stat()
 	// vfs := x.GetFS()
 
@@ -41,13 +40,13 @@ func write(x nfs.RPCContext, args *nfs.WRITE4args) (*nfs.WRITE4res, error) {
 	sizeWrote := uint32(0)
 	if args.Data != nil && len(args.Data) > 0 {
 		buff := bytes.NewReader(args.Data)
-		if size, err := io.CopyN(f, buff, int64(len(args.Data))); err != nil {
+		size, err := io.CopyN(f, buff, int64(len(args.Data)))
+		if err != nil {
 			log.Warnf("io.CopyN(): %v", err)
 			return &nfs.WRITE4res{Status: nfs.NFS4ERR_PERM}, nil
-		} else {
-			sizeWrote = uint32(size)
-			// log.Printf("  %d bytes wrote.", sizeWrote)
 		}
+		sizeWrote = uint32(size)
+		// log.Printf("  %d bytes wrote.", sizeWrote)
 	} else {
 		// log.Printf("  no data to be written.")
 	}
@@ -59,11 +58,10 @@ func write(x nfs.RPCContext, args *nfs.WRITE4args) (*nfs.WRITE4res, error) {
 		switch args.Stable {
 		case nfs.DATA_SYNC4:
 			fsync = true
-			break
 		case nfs.FILE_SYNC4:
 			fsync = true
-			break
 		}
+
 		if fsync {
 			if err := f.Sync(); err != nil {
 				log.Warnf("f.Sync(%s): %v", f.Name(), err)

--- a/nfs/rpc.go
+++ b/nfs/rpc.go
@@ -72,10 +72,8 @@ func (h *RPCMsgCall) String() string {
 		switch h.Vers {
 		case 3:
 			procName = Proc3Name(h.Proc)
-			break
 		case 4:
 			procName = Proc4Name(h.Proc)
-			break
 		}
 	}
 	return fmt.Sprintf(

--- a/server/mux_v3.go
+++ b/server/mux_v3.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	// "github.com/smallfz/libnfs-go/log"
-	"fmt"
+	"errors"
+
 	"github.com/smallfz/libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/nfs"
 	handlers "github.com/smallfz/libnfs-go/nfs/implv3"
@@ -51,5 +51,5 @@ func (x *Mux) HandleProc(h *nfs.RPCMsgCall) (int, error) {
 	case nfs.ProcReaddirPlus:
 		return handlers.ReaddirPlus(h, x)
 	}
-	return 0, fmt.Errorf("not implemented.")
+	return 0, errors.New("not implemented")
 }

--- a/server/mux_v4.go
+++ b/server/mux_v4.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/smallfz/libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/nfs"
 	v4 "github.com/smallfz/libnfs-go/nfs/implv4"
@@ -38,5 +39,5 @@ func (x *Muxv4) HandleProc(h *nfs.RPCMsgCall) (int, error) {
 	case nfs.PROC4_COMPOUND:
 		return v4.Compound(h, x)
 	}
-	return 0, fmt.Errorf("Not implemented: %s", nfs.Proc4Name(h.Proc))
+	return 0, fmt.Errorf("not implemented: %s", nfs.Proc4Name(h.Proc))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -2,48 +2,47 @@
 //
 // Package server provides a server implementation of nfs v4.
 //
-//     import (
-//     	"fmt"
-//     	"github.com/smallfz/libnfs-go/log"
-//     	"github.com/smallfz/libnfs-go/memfs"
-//     	"github.com/smallfz/libnfs-go/server"
-//     	"os"
-//     )
+//	import (
+//		"fmt"
+//		"github.com/smallfz/libnfs-go/log"
+//		"github.com/smallfz/libnfs-go/memfs"
+//		"github.com/smallfz/libnfs-go/server"
+//		"os"
+//	)
 //
-//     func main() {
-//     	mfs := memfs.NewMemFS()
-//     	backend := memfs.NewBackend(mfs)
+//	func main() {
+//		mfs := memfs.NewMemFS()
+//		backend := memfs.NewBackend(mfs)
 //
-//     	mfs.MkdirAll("/mount", os.FileMode(0755))
-//     	mfs.MkdirAll("/test", os.FileMode(0755))
-//     	mfs.MkdirAll("/test2", os.FileMode(0755))
-//     	mfs.MkdirAll("/many", os.FileMode(0755))
+//		mfs.MkdirAll("/mount", os.FileMode(0755))
+//		mfs.MkdirAll("/test", os.FileMode(0755))
+//		mfs.MkdirAll("/test2", os.FileMode(0755))
+//		mfs.MkdirAll("/many", os.FileMode(0755))
 //
-//     	perm := os.FileMode(0755)
-//     	for i := 0; i < 256; i++ {
-//          	mfs.MkdirAll(fmt.Sprintf("/many/sub-%d", i+1), perm)
-//     	}
+//		perm := os.FileMode(0755)
+//		for i := 0; i < 256; i++ {
+//	     	mfs.MkdirAll(fmt.Sprintf("/many/sub-%d", i+1), perm)
+//		}
 //
-//     	svr, err := server.NewServerTCP(2049, backend)
-//     	if err != nil {
-//          	log.Errorf("server.NewServerTCP: %v", err)
-//          	return
-//     	}
+//		svr, err := server.NewServerTCP(2049, backend)
+//		if err != nil {
+//	     	log.Errorf("server.NewServerTCP: %v", err)
+//	     	return
+//		}
 //
-//     	if err := svr.Serve(); err != nil {
-//          	log.Errorf("svr.Serve: %v", err)
-//     	}
-//     }
-//
-//
+//		if err := svr.Serve(); err != nil {
+//	     	log.Errorf("svr.Serve: %v", err)
+//		}
+//	}
 package server
 
 import (
 	"context"
 	"fmt"
+	"net"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"net"
 )
 
 type Server struct {
@@ -51,12 +50,17 @@ type Server struct {
 	backend  nfs.Backend
 }
 
-func NewServerTCP(port int, backend nfs.Backend) (*Server, error) {
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+func NewServerTCP(address string, backend nfs.Backend) (*Server, error) {
+	ln, err := net.Listen("tcp", address)
 	if err != nil {
-		return nil, fmt.Errorf("net.Listen: %v", err)
+		return nil, fmt.Errorf("net.Listen: %w", err)
 	}
-	return &Server{listener: ln, backend: backend}, nil
+	return NewServer(ln, backend)
+}
+
+// NewServer returns a new server with the given listener (e.g. net.Listen, tls.Listen, etc.)
+func NewServer(l net.Listener, backend nfs.Backend) (*Server, error) {
+	return &Server{listener: l, backend: backend}, nil
 }
 
 func (s *Server) Serve() error {
@@ -69,7 +73,7 @@ func (s *Server) Serve() error {
 
 	for {
 		if conn, err := s.listener.Accept(); err != nil {
-			return fmt.Errorf("listener.Accept: %v", err)
+			return fmt.Errorf("listener.Accept: %w", err)
 		} else {
 			go func() {
 				defer conn.Close()
@@ -79,6 +83,4 @@ func (s *Server) Serve() error {
 			}()
 		}
 	}
-
-	return nil
 }

--- a/unixfs/file.go
+++ b/unixfs/file.go
@@ -1,0 +1,38 @@
+package unixfs
+
+import (
+	"os"
+
+	"github.com/smallfz/libnfs-go/fs"
+)
+
+type file struct {
+	os.File
+}
+
+func (f *file) Readdir(n int) ([]fs.FileInfo, error) {
+	infos, err := f.File.Readdir(n)
+	if err != nil {
+		return nil, err
+	}
+
+	var fis []fs.FileInfo
+	for _, info := range infos {
+		fis = append(fis, statFromInfo(info))
+	}
+
+	return fis, nil
+}
+
+func (f *file) Stat() (fs.FileInfo, error) {
+	info, err := f.File.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return statFromInfo(info), nil
+}
+
+func (f *file) Truncate() error {
+	return f.File.Truncate(0)
+}

--- a/unixfs/file_info.go
+++ b/unixfs/file_info.go
@@ -1,0 +1,25 @@
+package unixfs
+
+import (
+	"io/fs"
+	"os"
+)
+
+type FileInfo struct {
+	fs.FileInfo
+}
+
+func Stat(name string) (*FileInfo, error) {
+	fi, err := os.Lstat(name) // Do not follow links
+	if err != nil {
+		return nil, err
+	}
+
+	return statFromInfo(fi), nil
+}
+
+func statFromInfo(fi fs.FileInfo) *FileInfo {
+	return &FileInfo{
+		FileInfo: fi,
+	}
+}

--- a/unixfs/file_info_darwin.go
+++ b/unixfs/file_info_darwin.go
@@ -1,0 +1,22 @@
+package unixfs
+
+import (
+	"syscall"
+	"time"
+)
+
+func (fi FileInfo) ATime() time.Time {
+	return time.Unix(fi.FileInfo.Sys().(*syscall.Stat_t).Atimespec.Unix())
+}
+
+func (fi FileInfo) CTime() time.Time {
+	return time.Unix(fi.FileInfo.Sys().(*syscall.Stat_t).Ctimespec.Unix())
+}
+
+func (fi FileInfo) NumLinks() int {
+	return int(fi.FileInfo.Sys().(*syscall.Stat_t).Nlink)
+}
+
+func (fi FileInfo) Inode() uint64 {
+	return fi.FileInfo.Sys().(*syscall.Stat_t).Ino
+}

--- a/unixfs/file_info_linux.go
+++ b/unixfs/file_info_linux.go
@@ -1,0 +1,22 @@
+package unixfs
+
+import (
+	"syscall"
+	"time"
+)
+
+func (fi FileInfo) ATime() time.Time {
+	return time.Unix(fi.FileInfo.Sys().(*syscall.Stat_t).Atim.Unix())
+}
+
+func (fi FileInfo) CTime() time.Time {
+	return time.Unix(fi.FileInfo.Sys().(*syscall.Stat_t).Ctim.Unix())
+}
+
+func (fi FileInfo) NumLinks() int {
+	return int(fi.FileInfo.Sys().(*syscall.Stat_t).Nlink)
+}
+
+func (fi FileInfo) Inode() uint64 {
+	return fi.FileInfo.Sys().(*syscall.Stat_t).Ino
+}

--- a/unixfs/inode.go
+++ b/unixfs/inode.go
@@ -1,0 +1,136 @@
+package unixfs
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sync"
+
+	"github.com/smallfz/libnfs-go/log"
+	"github.com/smallfz/libnfs-go/memfs"
+)
+
+const InvalidID = memfs.InvalidId
+
+// Inodes contain the mapping of paths and their inode IDs because
+// it's more safe to rely on them instead of other kind of IDs.
+type Inodes struct {
+	mu     sync.Mutex
+	inodes map[uint64]string
+	paths  map[string]uint64
+}
+
+func NewInodes() *Inodes {
+	return &Inodes{
+		inodes: make(map[uint64]string),
+		paths:  make(map[string]uint64),
+	}
+}
+
+// Scan reads all the inode's IDs under the given workdir.
+// It can take a while depending on the number of inodes to read and disk perfomance.
+func (i *Inodes) Scan(workdir string) error {
+	// On macOS we can avoid scanning all the workdir by using these 2 commands:
+	//
+	// [~]>> stat $HOME
+	// 16777220 30109 drwxr-xr-x 75 mdouchement staff 0 2400 "Sep 14 10:07:41 2023" "Sep 14 10:07:51 2023" "Sep 14 10:07:51 2023" "Aug 10 15:49:15 2022" 4096 0 0 /Users/mdouchement
+	// [~]>> GetFileInfo /.vol/16777220/30109
+	// directory: "/Users/mdouchement"
+	// attributes: avbstclinmedz
+	// created: 08/10/2022 15:49:15
+	// modified: 09/14/2023 10:08:02
+	//
+	// For the moment, no equivalent feature has been found on GNU/Linux.
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	log.Info("Scanning inodes...")
+
+	return filepath.WalkDir(workdir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		inode := statFromInfo(info).Inode()
+		i.inodes[inode] = path
+		i.paths[path] = inode
+		log.Debug("  ", inode, " ", path)
+		return nil
+	})
+}
+
+func (i *Inodes) UpdateAll(name string) error {
+	var notfirst bool // Refresh full path because it may change due to UnixFS actions.
+
+	for {
+		if notfirst && i.ExistPath(name) {
+			// The workdir (root folder) exists so we should never go outside the workdir.
+			break
+		}
+
+		fi, err := Stat(name)
+		if err != nil {
+			return err
+		}
+
+		i.Add(fi.Inode(), name)
+
+		name = filepath.Dir(name)
+		notfirst = true
+	}
+
+	return nil
+}
+
+func (i *Inodes) GetPath(inode uint64) string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	return i.inodes[inode]
+}
+
+func (i *Inodes) GetID(path string) uint64 {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	return i.paths[path]
+}
+
+func (i *Inodes) ExistPath(path string) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	_, ok := i.paths[path]
+	return ok
+}
+
+func (i *Inodes) Add(inode uint64, path string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.inodes[inode] = path
+	i.paths[path] = inode
+}
+
+func (i *Inodes) RemoveID(inode uint64) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	path := i.inodes[inode]
+	delete(i.inodes, inode)
+	delete(i.paths, path)
+}
+
+func (i *Inodes) RemovePath(path string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	inode := i.paths[path]
+	delete(i.inodes, inode)
+	delete(i.paths, path)
+}

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -1,0 +1,294 @@
+package unixfs
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/smallfz/libnfs-go/fs"
+)
+
+type UnixFS struct {
+	workdir    string
+	inodes     *Inodes
+	attributes fs.Attributes
+}
+
+func New(workdir string) (*UnixFS, error) {
+	workdir, err := filepath.Abs(workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	inodes := NewInodes()
+	err = inodes.Scan(workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UnixFS{
+		workdir: workdir,
+		inodes:  inodes,
+		attributes: fs.Attributes{
+			LinkSupport:     true,
+			SymlinkSupport:  true,
+			ChownRestricted: true,  // Supported but chown is disabled by default for security reason
+			MaxName:         255,   // Common value
+			NoTrunc:         false, // Safe value
+		},
+	}, nil
+}
+
+func (s *UnixFS) Attributes() *fs.Attributes {
+	return &s.attributes
+}
+
+func (s *UnixFS) Stat(name string) (fs.FileInfo, error) {
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return Stat(name)
+}
+
+func (s *UnixFS) Chmod(name string, mode os.FileMode) error {
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(name, mode)
+}
+
+func (s *UnixFS) Chown(name string, uid, gid int) error {
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return err
+	}
+
+	return os.Lchown(name, uid, gid)
+}
+
+func (s *UnixFS) MkdirAll(name string, mode os.FileMode) error {
+	if name == fs.ROOT {
+		return nil
+	}
+
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return err
+	}
+
+	//
+
+	if err = os.MkdirAll(name, mode); err != nil {
+		return err
+	}
+
+	//
+
+	return s.inodes.UpdateAll(name)
+}
+
+func (s *UnixFS) Remove(name string) error {
+	if name == fs.ROOT {
+		return os.ErrPermission
+	}
+
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return err
+	}
+
+	//
+
+	if err = os.Remove(name); err != nil {
+		return err
+	}
+
+	//
+
+	s.inodes.RemovePath(name)
+	return nil
+}
+
+func (s *UnixFS) Rename(oldpath, newpath string) error {
+	if oldpath == fs.ROOT || newpath == fs.ROOT || oldpath == newpath {
+		return os.ErrPermission
+	}
+
+	oldpath, err := s.ResolveUnix(oldpath)
+	if err != nil {
+		return err
+	}
+
+	newpath, err = s.ResolveUnix(newpath)
+	if err != nil {
+		return err
+	}
+
+	//
+
+	if err = os.Rename(oldpath, newpath); err != nil {
+		return err
+	}
+
+	//
+
+	s.inodes.RemovePath(oldpath)
+	return s.inodes.UpdateAll(newpath)
+}
+
+func (s *UnixFS) Link(oldpath, newpath string) error {
+	if oldpath == fs.ROOT || newpath == fs.ROOT || oldpath == newpath {
+		return os.ErrPermission
+	}
+
+	oldpath, err := s.ResolveUnix(oldpath)
+	if err != nil {
+		return err
+	}
+
+	newpath, err = s.ResolveUnix(newpath)
+	if err != nil {
+		return err
+	}
+
+	//
+
+	if err = os.Link(oldpath, newpath); err != nil {
+		return err
+	}
+
+	//
+
+	return s.inodes.UpdateAll(newpath)
+}
+
+func (s *UnixFS) Symlink(oldpath, newpath string) error {
+	if oldpath == fs.ROOT || newpath == fs.ROOT || oldpath == newpath {
+		return os.ErrPermission
+	}
+
+	newpath, err := s.ResolveUnix(newpath)
+	if err != nil {
+		return err
+	}
+
+	//
+
+	// We do not check `oldpath', we let the OS put the data in the link file.
+	if err = os.Symlink(oldpath, newpath); err != nil {
+		return err
+	}
+
+	return s.inodes.UpdateAll(newpath)
+}
+
+func (s *UnixFS) Readlink(name string) (string, error) {
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return "", err
+	}
+
+	return os.Readlink(name)
+}
+
+func (s *UnixFS) Open(name string) (fs.File, error) {
+	return s.OpenFile(name, os.O_RDONLY, os.FileMode(0o644))
+}
+
+func (s *UnixFS) OpenFile(name string, flag int, mode os.FileMode) (fs.File, error) {
+	name, err := s.ResolveUnix(name)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(name, flag, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	file := &file{
+		File: *f,
+	}
+
+	{
+		i, err := f.Stat()
+		if err != nil {
+			return nil, err
+		}
+		s.inodes.Add(statFromInfo(i).Inode(), name)
+	}
+
+	return file, nil
+}
+
+func (s *UnixFS) GetFileId(fi fs.FileInfo) uint64 {
+	switch i := fi.(type) {
+	case *FileInfo:
+		return i.Inode()
+	default:
+		return InvalidID
+	}
+}
+
+func (s *UnixFS) GetHandle(fi fs.FileInfo) ([]byte, error) {
+	id := s.GetFileId(fi)
+	if id == InvalidID {
+		return nil, os.ErrNotExist
+	}
+
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, id)
+	return buf, nil
+}
+
+func (s *UnixFS) GetRootHandle() []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, s.inodes.GetID(s.workdir))
+	return buf
+}
+
+// ResolveHandle resolves a file-handle(eg. nfs_fh4) to a full path name.
+func (s *UnixFS) ResolveHandle(fh []byte) (string, error) {
+	var id uint64
+	if len(fh) <= 8 {
+		id = binary.BigEndian.Uint64(fh)
+	} else {
+		id = binary.BigEndian.Uint64(fh[:8])
+	}
+
+	if id == InvalidID {
+		return "", os.ErrNotExist
+	}
+
+	path := s.inodes.GetPath(id)
+	if path == "" {
+		return "", os.ErrNotExist
+	}
+
+	return s.ResolveNFS(path), nil
+}
+
+//
+// Helpers
+//
+
+func (s *UnixFS) ResolveUnix(name string) (string, error) {
+	name = fs.Abs(name)
+	name = filepath.FromSlash(name)
+	return filepath.Join(s.workdir, name), nil
+}
+
+func (s *UnixFS) ResolveNFS(name string) string {
+	name = strings.TrimPrefix(name, s.workdir)
+	name = filepath.ToSlash(name)
+	if name == "" {
+		name = "/"
+	}
+
+	return name
+}

--- a/unixfs/unixfs_test.go
+++ b/unixfs/unixfs_test.go
@@ -1,4 +1,4 @@
-package memfs
+package unixfs_test
 
 import (
 	"bytes"
@@ -8,12 +8,24 @@ import (
 	"testing"
 
 	"github.com/smallfz/libnfs-go/fs"
+	"github.com/smallfz/libnfs-go/unixfs"
 )
 
-var _ fs.FS = new(MemFS) // Check interface
+var _ fs.FS = new(unixfs.UnixFS) // Check interface
 
 func TestMemfsFileSeekRead(t *testing.T) {
-	vfs := NewMemFS()
+	workdir, err := os.MkdirTemp("", "unixfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("workdir:", workdir)
+
+	vfs, err := unixfs.New(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//
 
 	name := "hello.txt"
 	content := "hello world!"
@@ -55,7 +67,18 @@ func TestMemfsFileSeekRead(t *testing.T) {
 }
 
 func TestMemfsFileOpenTrunc(t *testing.T) {
-	vfs := NewMemFS()
+	workdir, err := os.MkdirTemp("", "unixfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("workdir:", workdir)
+
+	vfs, err := unixfs.New(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//
 
 	name := "hello.txt"
 	content := "hello world!"
@@ -114,7 +137,18 @@ func TestMemfsFileOpenTrunc(t *testing.T) {
 }
 
 func TestMemfsFileOperations(t *testing.T) {
-	vfs := NewMemFS()
+	workdir, err := os.MkdirTemp("", "unixfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("workdir:", workdir)
+
+	vfs, err := unixfs.New(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//
 
 	folder := "/webapp"
 	mode := os.FileMode(0o755)
@@ -254,7 +288,16 @@ func TestMemfsFileOperations(t *testing.T) {
 }
 
 func TestMemfsMkdir(t *testing.T) {
-	vfs := NewMemFS()
+	workdir, err := os.MkdirTemp("", "unixfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("workdir:", workdir)
+
+	vfs, err := unixfs.New(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// (1) create a folder
 

--- a/unixfs/verbose_unixfs.go
+++ b/unixfs/verbose_unixfs.go
@@ -1,0 +1,164 @@
+package unixfs
+
+import (
+	"os"
+
+	"github.com/smallfz/libnfs-go/fs"
+	"github.com/smallfz/libnfs-go/log"
+)
+
+type VerboseUnixFS struct {
+	UnixFS
+}
+
+func NewVerbose(workdir string) (*VerboseUnixFS, error) {
+	fs, err := New(workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VerboseUnixFS{UnixFS: *fs}, nil
+}
+
+func (s *VerboseUnixFS) Chmod(name string, mode os.FileMode) error {
+	log.Infof("unixfs.Chmod(%s, %o)", name, mode)
+
+	err := s.UnixFS.Chmod(name, mode)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *VerboseUnixFS) Chown(name string, uid, gid int) error {
+	log.Infof("unixfs.Chown(%s, %d, %d)", name, uid, gid)
+
+	err := s.UnixFS.Chown(name, uid, gid)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *VerboseUnixFS) MkdirAll(name string, mode os.FileMode) error {
+	log.Infof("unixfs.MkdirAll(%s, %o)", name, mode)
+
+	err := s.UnixFS.MkdirAll(name, mode)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *VerboseUnixFS) Remove(name string) error {
+	log.Infof("unixfs.Remove(%s)", name)
+
+	err := s.UnixFS.Remove(name)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *VerboseUnixFS) Rename(oldpath, newpath string) error {
+	log.Infof("unixfs.Rename(%s, %s)", oldpath, newpath)
+
+	err := s.UnixFS.Rename(oldpath, newpath)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *VerboseUnixFS) Link(oldpath, newpath string) error {
+	log.Infof("unixfs.Link(%s, %s)", oldpath, newpath)
+
+	err := s.UnixFS.Link(oldpath, newpath)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *VerboseUnixFS) Stat(name string) (fs.FileInfo, error) {
+	log.Infof("unixfs.Stat(%s)", name)
+
+	fi, err := s.UnixFS.Stat(name)
+	if err != nil {
+		log.Warn(err)
+		return nil, err
+	}
+
+	return fi, nil
+}
+
+func (s *VerboseUnixFS) Open(name string) (fs.File, error) {
+	log.Infof("unixfs.Open(%s)", name)
+
+	return s.OpenFile(name, os.O_RDONLY, os.FileMode(0o644))
+}
+
+func (s *VerboseUnixFS) OpenFile(name string, flag int, mode os.FileMode) (fs.File, error) {
+	log.Infof("unixfs.OpenFile(%s, %d, %o)", name, flag, mode)
+
+	f, err := s.UnixFS.OpenFile(name, flag, mode)
+	if err != nil {
+		log.Warn(err)
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func (s *VerboseUnixFS) GetFileId(fi fs.FileInfo) uint64 {
+	log.Infof("unixfs.GetFileId: %#v", fi)
+
+	inode := s.UnixFS.GetFileId(fi)
+	log.Info("  id: ", inode)
+
+	return inode
+}
+
+func (s *VerboseUnixFS) GetHandle(fi fs.FileInfo) ([]byte, error) {
+	log.Infof("GetHandle: %s", fi.Name())
+
+	b, err := s.UnixFS.GetHandle(fi)
+	if err != nil {
+		log.Warn(err)
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func (s *VerboseUnixFS) GetRootHandle() []byte {
+	b := s.UnixFS.GetRootHandle()
+	log.Infof("unixfs.GetRootHandle: %x", b)
+
+	return b
+}
+
+// ResolveHandle resolves a file-handle(eg. nfs_fh4) to a full path name.
+func (s *VerboseUnixFS) ResolveHandle(fh []byte) (string, error) {
+	log.Infof("unixfs.ResolveHandle: %x", fh)
+
+	v, err := s.UnixFS.ResolveHandle(fh)
+	if err != nil {
+		log.Warn(err)
+		return "", err
+	}
+
+	return v, nil
+}

--- a/utils/rand.go
+++ b/utils/rand.go
@@ -7,6 +7,8 @@ import (
 
 func RandUint32() uint32 {
 	b := make([]byte, 4)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
 	return binary.BigEndian.Uint32(b)
 }

--- a/xdr/reader.go
+++ b/xdr/reader.go
@@ -2,9 +2,11 @@ package xdr
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+
 	// "libnfs-go/log"
 	"math"
 	"reflect"
@@ -95,12 +97,12 @@ func (r *Reader) ReadUint32() (uint32, error) {
 
 func (r *Reader) ReadValue(v reflect.Value) (int, error) {
 	if !v.IsValid() {
-		return 0, fmt.Errorf("invalid target.")
+		return 0, errors.New("invalid target")
 	}
 
 	kind := v.Kind()
 	if kind != reflect.Ptr {
-		return 0, fmt.Errorf("ReadAs: expects a ptr target.")
+		return 0, errors.New("ReadAs: expects a ptr target")
 	}
 
 	kind = v.Elem().Kind()
@@ -168,7 +170,7 @@ func (r *Reader) ReadValue(v reflect.Value) (int, error) {
 			v.Elem().Set(v1)
 			return size, nil
 		}
-		return size, fmt.Errorf("unable to assign %T to %s.", iv, kind)
+		return size, fmt.Errorf("unable to assign %T to %s", iv, kind)
 
 	case reflect.Int64, reflect.Uint64:
 		// todo: convert to xdr.b8
@@ -188,7 +190,7 @@ func (r *Reader) ReadValue(v reflect.Value) (int, error) {
 			v.Elem().Set(v1)
 			return size, nil
 		}
-		return size, fmt.Errorf("unable to assign %T to %s.", iv, kind)
+		return size, fmt.Errorf("unable to assign %T to %s", iv, kind)
 
 	case reflect.Array:
 		// fixed length array
@@ -309,7 +311,6 @@ func (r *Reader) ReadValue(v reflect.Value) (int, error) {
 				if fv.IsNil() {
 					pToFv = reflect.New(fv.Type())
 				}
-				break
 			}
 
 			if size, err := r.ReadValue(pToFv); err != nil {
@@ -324,10 +325,8 @@ func (r *Reader) ReadValue(v reflect.Value) (int, error) {
 		return sizeConsumed, nil
 
 	default:
-		return 0, fmt.Errorf("Type not supported: %s.", kind)
-
+		return 0, fmt.Errorf("type not supported: %s", kind)
 	}
-	return 0, nil
 }
 
 func (r *Reader) ReadAs(target interface{}) (int, error) {

--- a/xdr/reader_test.go
+++ b/xdr/reader_test.go
@@ -189,7 +189,6 @@ func TestReaderReadAs_varSizeArr(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func TestReaderReadAs_fixedSizeArr(t *testing.T) {
@@ -223,7 +222,6 @@ func TestReaderReadAs_fixedSizeArr(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func TestReaderReadAs_varSizeBytes(t *testing.T) {
@@ -262,7 +260,6 @@ func TestReaderReadAs_varSizeBytes(t *testing.T) {
 			fmt.Println(target0)
 		}
 	}
-
 }
 
 func TestReaderReadAs_fizedSizeBytes(t *testing.T) {
@@ -297,7 +294,6 @@ func TestReaderReadAs_fizedSizeBytes(t *testing.T) {
 			fmt.Println(target0)
 		}
 	}
-
 }
 
 type structTestB struct {
@@ -318,8 +314,8 @@ func TestReaderReadAs_struct(t *testing.T) {
 		Iv:   123,
 		Iv32: 456,
 		Values: []*structTestB{
-			&structTestB{Value: 789},
-			&structTestB{Value: 10010},
+			{Value: 789},
+			{Value: 10010},
 		},
 		SingleB: &structTestB{Value: 666},
 		PlainB:  structTestB{Value: 999},
@@ -408,5 +404,4 @@ func TestReaderReadAs_struct(t *testing.T) {
 			)
 		}
 	}
-
 }

--- a/xdr/writer.go
+++ b/xdr/writer.go
@@ -3,10 +3,11 @@ package xdr
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/smallfz/libnfs-go/log"
 	"io"
 	"math"
 	"reflect"
+
+	"github.com/smallfz/libnfs-go/log"
 )
 
 type Writer struct {
@@ -65,11 +66,11 @@ func (w *Writer) WriteValue(v reflect.Value) (int, error) {
 			vTo.Elem().Set(vmid)
 		} else {
 			log.Errorf(
-				"unable to assign %s to %s.",
+				"unable to assign %s to %s",
 				vtyp.Name(), vTo.Type().Name(),
 			)
 			return 0, fmt.Errorf(
-				"unable to assign %s to %s.",
+				"unable to assign %s to %s",
 				vtyp.Name(), vTo.Type().Name(),
 			)
 		}
@@ -85,11 +86,11 @@ func (w *Writer) WriteValue(v reflect.Value) (int, error) {
 			vTo.Elem().Set(vmid)
 		} else {
 			log.Errorf(
-				"unable to assign %s to %s.",
+				"unable to assign %s to %s",
 				vtyp.Name(), vTo.Type().Name(),
 			)
 			return 0, fmt.Errorf(
-				"unable to assign %s to %s.",
+				"unable to assign %s to %s",
 				vtyp.Name(), vTo.Type().Name(),
 			)
 		}
@@ -206,7 +207,7 @@ func (w *Writer) WriteValue(v reflect.Value) (int, error) {
 
 	}
 
-	return 0, fmt.Errorf("Type not supported: %s.", vtyp.Name())
+	return 0, fmt.Errorf("type not supported: %s", vtyp.Name())
 }
 
 func (w *Writer) WriteBytesAutoPad(dat []byte) (int, error) {

--- a/xdr/writer_test.go
+++ b/xdr/writer_test.go
@@ -36,8 +36,8 @@ func TestWriter_Struct(t *testing.T) {
 		Iv:   123,
 		Iv32: 456,
 		Values: []*structTestB{
-			&structTestB{Value: 789},
-			&structTestB{Value: 10010},
+			{Value: 789},
+			{Value: 10010},
 		},
 		SingleB: &structTestB{Value: 666},
 		PlainB:  structTestB{Value: 999},


### PR DESCRIPTION
Go format with `gofumpt` tool.

UnixFS VFS implemented.
Change of the signature of some functions from the `server` package to match Golang's patterns.
Move backend to a dedicated package.

New supported functionalities (at least with UnixFS):
- Chown
- Rename
- Link
- Symlink
- Readlink

Tests with NFStest 3.2 with the following command `nfstest_posix --server localhost --nfsversion=4 --notty --createlog`:
- access: 37/58 pass
- chdir: 6/6 pass
- chmod: 2/16 pass
- close: 4/4 pass
- closedir: 1/1 pass
- creat: 8/8 pass
- fcnlt: 4/4 pass
- fcntl: 30/34 pass
- fdatasync: 2/2 pass
- fstat: 42/42 pass
- fstatvfs: 22/22 pass
- fsync: 2/2 pass
- link: 6/6 pass
- lseek: 10/10 pass
- lstat: 42/42 pass
- mkdir: 8/8 pass
- mmap: 15/15 pass
- munmap: 13/13 pass
- open: 30/31 pass
- opendir: 2/2 pass
- read: 5/5 pass
- readdir: 3/3 pass
- readlink: 9/9 pass
- rename: 14/14 pass
- rewinddir: 4/4 pass
- rmdir: 6/6 pass
- seekdir: 5/5 pass
- stat: 42/42 pass
- statvfs: 22/22 pass
- symlink: 4/4 pass
- sync: 2/2 pass
- telldir: 5/5 pass
- unlink: 12/12 pass
- write: 10/10 pass