### PR TITLE
Add unix authentication

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"bytes"
+
+	"github.com/smallfz/libnfs-go/fs"
+	"github.com/smallfz/libnfs-go/nfs"
+	"github.com/smallfz/libnfs-go/xdr"
+)
+
+func Null(_, _ *nfs.Auth) (*nfs.Auth, fs.Creds, error) {
+	return &nfs.Auth{Flavor: nfs.AUTH_FLAVOR_NULL, Body: []byte{}}, nil, nil
+}
+
+func Unix(cred, _ *nfs.Auth) (*nfs.Auth, fs.Creds, error) {
+	if cred.Flavor < nfs.AUTH_FLAVOR_UNIX {
+		return nil, nil, nfs.ErrTooWeak
+	}
+
+	var credentials Creds
+
+	if _, err := xdr.NewReader(bytes.NewBuffer(cred.Body)).ReadAs(&credentials); err != nil {
+		return nil, nil, err
+	}
+
+	return &nfs.Auth{Flavor: nfs.AUTH_FLAVOR_UNIX, Body: []byte{}}, &credentials, nil
+}
+
+type Creds struct {
+	ExpirationValue  uint32
+	Hostname         string
+	UID              uint32
+	GID              uint32
+	AdditionalGroups []uint32
+}
+
+func (c *Creds) Host() string {
+	return c.Hostname
+}
+
+func (c *Creds) Uid() uint32 {
+	return c.UID
+}
+
+func (c *Creds) Gid() uint32 {
+	return c.GID
+}
+
+func (c *Creds) Groups() []uint32 {
+	return c.AdditionalGroups
+}

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/smallfz/libnfs-go/auth"
 	"github.com/smallfz/libnfs-go/backend"
+	"github.com/smallfz/libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/memfs"
 	"github.com/smallfz/libnfs-go/server"
@@ -19,7 +21,10 @@ func main() {
 	log.UpdateLevel(log.DEBUG)
 
 	mfs := memfs.NewMemFS()
-	backend := backend.New(mfs)
+
+	// We don't need to create a new fs for each connection as memfs is opaque towards SetCreds.
+	// If the file system would depend on SetCreds, make sure to generate a new fs.FS for each connection.
+	backend := backend.New(func() fs.FS { return mfs }, auth.Null)
 
 	mfs.MkdirAll("/mount", os.FileMode(0o755))
 	mfs.MkdirAll("/test", os.FileMode(0o755))

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+type Creds interface {
+	Host() string
+	Uid() uint32
+	Gid() uint32
+	Groups() []uint32
+}
+
 type FileInfo interface {
 	os.FileInfo
 	ATime() time.Time
@@ -30,6 +37,9 @@ type WithId interface {
 
 // FS is the most essential interface that need to be implemeted in a derived nfs server.
 type FS interface {
+	// SetCreds is called before all other methods to indicate the credentials of the client.
+	SetCreds(Creds)
+
 	Open(string) (File, error)
 	OpenFile(string, int, os.FileMode) (File, error)
 	Stat(string) (FileInfo, error)

--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -217,6 +217,8 @@ func (s *MemFS) writeNode(n *memFsNode, dat []byte) {
 	n.size = int64(s.store.Size(n.nodeId))
 }
 
+func (s *MemFS) SetCreds(creds fs.Creds) {}
+
 func (s *MemFS) Open(name string) (fs.File, error) {
 	return s.OpenFile(name, os.O_RDONLY, os.FileMode(0o644))
 }

--- a/nfs/backend.go
+++ b/nfs/backend.go
@@ -12,6 +12,8 @@ type SessionState interface {
 	Conn() net.Conn
 }
 
+type AuthenticationHandler func(*Auth, *Auth) (*Auth, fs.Creds, error)
+
 type StatService interface {
 	// Cwd() string
 	// SetCwd(string) error
@@ -41,7 +43,11 @@ type StatService interface {
 
 // BackendSession has a lifetime exact as the client connection.
 type BackendSession interface {
+	// Authentication should return an Authentication handler.
+	Authentication() AuthenticationHandler
+
 	// GetFS should return a FS implementation.
+	// The backend should cache
 	GetFS() fs.FS
 
 	// GetStatService returns a StateService in implementation.

--- a/nfs/context.go
+++ b/nfs/context.go
@@ -8,6 +8,7 @@ import (
 type RPCContext interface {
 	Reader() *xdr.Reader
 	Writer() *xdr.Writer
+	Authenticate(*Auth, *Auth) (*Auth, error) // Handle authentication and calls fs.FS.SetCreds(). Returns *Auth to reply to the client.
 	GetFS() fs.FS
 	Stat() StatService
 }

--- a/nfs/implv3/access.go
+++ b/nfs/implv3/access.go
@@ -2,9 +2,10 @@ package implv3
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"time"
 )
 
 func Access(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
@@ -30,25 +31,45 @@ func Access(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 		"access: root = %s, access = %x", string(fh3), access,
 	))
 
+	resp, err := ctx.Authenticate(h.Cred, h.Verf)
+	if authErr, ok := err.(*nfs.AuthError); ok {
+		rh := &nfs.RPCMsgReply{
+			Xid:       h.Xid,
+			MsgType:   nfs.RPC_REPLY,
+			ReplyStat: nfs.MSG_DENIED,
+		}
+
+		if _, err := w.WriteAny(rh); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(nfs.REJECT_AUTH_ERROR); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(authErr.Code); err != nil {
+			return sizeConsumed, err
+		}
+
+		return sizeConsumed, nil
+	} else if err != nil {
+		return sizeConsumed, err
+	}
+
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return sizeConsumed, err
 	}
 
-	auth := &nfs.Auth{
-		Flavor: nfs.AUTH_FLAVOR_NULL,
-		Body:   []byte{},
-	}
-	if _, err := w.WriteAny(auth); err != nil {
+	if _, err := w.WriteAny(resp); err != nil {
 		return sizeConsumed, err
 	}
 
-	acceptStat := nfs.ACCEPT_SUCCESS
-	if _, err := w.WriteUint32(acceptStat); err != nil {
+	if _, err := w.WriteUint32(nfs.ACCEPT_SUCCESS); err != nil {
 		return sizeConsumed, err
 	}
 

--- a/nfs/implv3/fsinfo.go
+++ b/nfs/implv3/fsinfo.go
@@ -2,9 +2,10 @@ package implv3
 
 import (
 	// "fmt"
+	"time"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"time"
 	// "github.com/davecgh/go-xdr/xdr2"
 )
 
@@ -23,25 +24,45 @@ func FsInfo(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 
 	log.Infof("fsinfo: root = %s", string(fh3))
 
+	resp, err := ctx.Authenticate(h.Cred, h.Verf)
+	if authErr, ok := err.(*nfs.AuthError); ok {
+		rh := &nfs.RPCMsgReply{
+			Xid:       h.Xid,
+			MsgType:   nfs.RPC_REPLY,
+			ReplyStat: nfs.MSG_DENIED,
+		}
+
+		if _, err := w.WriteAny(rh); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(nfs.REJECT_AUTH_ERROR); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(authErr.Code); err != nil {
+			return sizeConsumed, err
+		}
+
+		return sizeConsumed, nil
+	} else if err != nil {
+		return sizeConsumed, err
+	}
+
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return sizeConsumed, err
 	}
 
-	auth := &nfs.Auth{
-		Flavor: nfs.AUTH_FLAVOR_NULL,
-		Body:   []byte{},
-	}
-	if _, err := w.WriteAny(auth); err != nil {
+	if _, err := w.WriteAny(resp); err != nil {
 		return sizeConsumed, err
 	}
 
-	acceptStat := nfs.ACCEPT_SUCCESS
-	if _, err := w.WriteUint32(acceptStat); err != nil {
+	if _, err := w.WriteUint32(nfs.ACCEPT_SUCCESS); err != nil {
 		return sizeConsumed, err
 	}
 

--- a/nfs/implv3/fsstat.go
+++ b/nfs/implv3/fsstat.go
@@ -2,9 +2,10 @@ package implv3
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"time"
 )
 
 func FsStat(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
@@ -22,25 +23,45 @@ func FsStat(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 
 	log.Info(fmt.Sprintf("fsstat: root = %v", fh3))
 
+	resp, err := ctx.Authenticate(h.Cred, h.Verf)
+	if authErr, ok := err.(*nfs.AuthError); ok {
+		rh := &nfs.RPCMsgReply{
+			Xid:       h.Xid,
+			MsgType:   nfs.RPC_REPLY,
+			ReplyStat: nfs.MSG_DENIED,
+		}
+
+		if _, err := w.WriteAny(rh); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(nfs.REJECT_AUTH_ERROR); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(authErr.Code); err != nil {
+			return sizeConsumed, err
+		}
+
+		return sizeConsumed, nil
+	} else if err != nil {
+		return sizeConsumed, err
+	}
+
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return sizeConsumed, err
 	}
 
-	auth := &nfs.Auth{
-		Flavor: nfs.AUTH_FLAVOR_NULL,
-		Body:   []byte{},
-	}
-	if _, err := w.WriteAny(auth); err != nil {
+	if _, err := w.WriteAny(resp); err != nil {
 		return sizeConsumed, err
 	}
 
-	acceptStat := nfs.ACCEPT_SUCCESS
-	if _, err := w.WriteUint32(acceptStat); err != nil {
+	if _, err := w.WriteUint32(nfs.ACCEPT_SUCCESS); err != nil {
 		return sizeConsumed, err
 	}
 

--- a/nfs/implv3/getattr.go
+++ b/nfs/implv3/getattr.go
@@ -2,9 +2,10 @@ package implv3
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"time"
 	// "github.com/davecgh/go-xdr/xdr2"
 )
 
@@ -43,25 +44,45 @@ func GetAttr(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 
 	log.Infof("getattr: fh3 = %s", string(fh3))
 
+	resp, err := ctx.Authenticate(h.Cred, h.Verf)
+	if authErr, ok := err.(*nfs.AuthError); ok {
+		rh := &nfs.RPCMsgReply{
+			Xid:       h.Xid,
+			MsgType:   nfs.RPC_REPLY,
+			ReplyStat: nfs.MSG_DENIED,
+		}
+
+		if _, err := w.WriteAny(rh); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(nfs.REJECT_AUTH_ERROR); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(authErr.Code); err != nil {
+			return sizeConsumed, err
+		}
+
+		return sizeConsumed, nil
+	} else if err != nil {
+		return sizeConsumed, err
+	}
+
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return sizeConsumed, err
 	}
 
-	auth := &nfs.Auth{
-		Flavor: nfs.AUTH_FLAVOR_NULL,
-		Body:   []byte{},
-	}
-	if _, err := w.WriteAny(auth); err != nil {
+	if _, err := w.WriteAny(resp); err != nil {
 		return sizeConsumed, err
 	}
 
-	acceptStat := nfs.ACCEPT_SUCCESS
-	if _, err := w.WriteUint32(acceptStat); err != nil {
+	if _, err := w.WriteUint32(nfs.ACCEPT_SUCCESS); err != nil {
 		return sizeConsumed, err
 	}
 

--- a/nfs/implv3/lookup.go
+++ b/nfs/implv3/lookup.go
@@ -3,10 +3,11 @@ package implv3
 import (
 	"bytes"
 	"fmt"
+	"time"
+
 	fstools "github.com/smallfz/libnfs-go/fs"
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"time"
 )
 
 func Lookup(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
@@ -26,25 +27,45 @@ func Lookup(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 		"lookup: dir = %v, filename = %v", args.Dir, args.Filename,
 	))
 
+	resp, err := ctx.Authenticate(h.Cred, h.Verf)
+	if authErr, ok := err.(*nfs.AuthError); ok {
+		rh := &nfs.RPCMsgReply{
+			Xid:       h.Xid,
+			MsgType:   nfs.RPC_REPLY,
+			ReplyStat: nfs.MSG_DENIED,
+		}
+
+		if _, err := w.WriteAny(rh); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(nfs.REJECT_AUTH_ERROR); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(authErr.Code); err != nil {
+			return sizeConsumed, err
+		}
+
+		return sizeConsumed, nil
+	} else if err != nil {
+		return sizeConsumed, err
+	}
+
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return sizeConsumed, err
 	}
 
-	auth := &nfs.Auth{
-		Flavor: nfs.AUTH_FLAVOR_NULL,
-		Body:   []byte{},
-	}
-	if _, err := w.WriteAny(auth); err != nil {
+	if _, err := w.WriteAny(resp); err != nil {
 		return sizeConsumed, err
 	}
 
-	acceptStat := nfs.ACCEPT_SUCCESS
-	if _, err := w.WriteUint32(acceptStat); err != nil {
+	if _, err := w.WriteUint32(nfs.ACCEPT_SUCCESS); err != nil {
 		return sizeConsumed, err
 	}
 

--- a/nfs/implv3/pathconf.go
+++ b/nfs/implv3/pathconf.go
@@ -1,9 +1,10 @@
 package implv3
 
 import (
+	"time"
+
 	"github.com/smallfz/libnfs-go/log"
 	"github.com/smallfz/libnfs-go/nfs"
-	"time"
 )
 
 func PathConf(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
@@ -21,25 +22,45 @@ func PathConf(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 
 	log.Infof("pathconf: path = %s", string(fh3))
 
+	resp, err := ctx.Authenticate(h.Cred, h.Verf)
+	if authErr, ok := err.(*nfs.AuthError); ok {
+		rh := &nfs.RPCMsgReply{
+			Xid:       h.Xid,
+			MsgType:   nfs.RPC_REPLY,
+			ReplyStat: nfs.MSG_DENIED,
+		}
+
+		if _, err := w.WriteAny(rh); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(nfs.REJECT_AUTH_ERROR); err != nil {
+			return sizeConsumed, err
+		}
+
+		if _, err := w.WriteUint32(authErr.Code); err != nil {
+			return sizeConsumed, err
+		}
+
+		return sizeConsumed, nil
+	} else if err != nil {
+		return sizeConsumed, err
+	}
+
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return sizeConsumed, err
 	}
 
-	auth := &nfs.Auth{
-		Flavor: nfs.AUTH_FLAVOR_NULL,
-		Body:   []byte{},
-	}
-	if _, err := w.WriteAny(auth); err != nil {
+	if _, err := w.WriteAny(resp); err != nil {
 		return sizeConsumed, err
 	}
 
-	acceptStat := nfs.ACCEPT_SUCCESS
-	if _, err := w.WriteUint32(acceptStat); err != nil {
+	if _, err := w.WriteUint32(nfs.ACCEPT_SUCCESS); err != nil {
 		return sizeConsumed, err
 	}
 

--- a/nfs/implv3/void.go
+++ b/nfs/implv3/void.go
@@ -13,7 +13,7 @@ func Void(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return 0, err

--- a/nfs/implv4/void.go
+++ b/nfs/implv4/void.go
@@ -10,7 +10,7 @@ func Void(h *nfs.RPCMsgCall, ctx nfs.RPCContext) (int, error) {
 	rh := &nfs.RPCMsgReply{
 		Xid:       h.Xid,
 		MsgType:   nfs.RPC_REPLY,
-		ReplyStat: nfs.ACCEPT_SUCCESS,
+		ReplyStat: nfs.MSG_ACCEPTED,
 	}
 	if _, err := w.WriteAny(rh); err != nil {
 		return 0, err

--- a/nfs/rpc.go
+++ b/nfs/rpc.go
@@ -49,6 +49,19 @@ type Auth struct {
 	Body   []byte
 }
 
+type AuthError struct {
+	Code uint32
+}
+
+func (err *AuthError) Error() string {
+	return fmt.Sprintf("auth error: %d", err.Code)
+}
+
+var (
+	ErrBadCredentials = &AuthError{Code: AUTH_BADCRED}
+	ErrTooWeak        = &AuthError{Code: AUTH_TOOWEAK}
+)
+
 func NewEmptyAuth() *Auth {
 	return &Auth{Flavor: 0, Body: []byte{}}
 }

--- a/server/mux_v3.go
+++ b/server/mux_v3.go
@@ -12,6 +12,7 @@ import (
 type Mux struct {
 	reader *xdr.Reader
 	writer *xdr.Writer
+	auth   nfs.AuthenticationHandler
 	fs     fs.FS
 	stat   nfs.StatService
 }
@@ -22,6 +23,16 @@ func (x *Mux) Reader() *xdr.Reader {
 
 func (x *Mux) Writer() *xdr.Writer {
 	return x.writer
+}
+
+func (x *Mux) Authenticate(cred, verf *nfs.Auth) (*nfs.Auth, error) {
+	resp, creds, err := x.auth(cred, verf)
+
+	if err != nil {
+		x.fs.SetCreds(creds)
+	}
+
+	return resp, err
 }
 
 func (x *Mux) Stat() nfs.StatService {

--- a/server/mux_v3.go
+++ b/server/mux_v3.go
@@ -28,7 +28,7 @@ func (x *Mux) Writer() *xdr.Writer {
 func (x *Mux) Authenticate(cred, verf *nfs.Auth) (*nfs.Auth, error) {
 	resp, creds, err := x.auth(cred, verf)
 
-	if err != nil {
+	if err == nil {
 		x.fs.SetCreds(creds)
 	}
 

--- a/server/mux_v4.go
+++ b/server/mux_v4.go
@@ -28,7 +28,7 @@ func (x *Muxv4) Writer() *xdr.Writer {
 func (x *Muxv4) Authenticate(cred, verf *nfs.Auth) (*nfs.Auth, error) {
 	resp, creds, err := x.auth(cred, verf)
 
-	if err != nil {
+	if err == nil {
 		x.fs.SetCreds(creds)
 	}
 

--- a/server/session.go
+++ b/server/session.go
@@ -53,6 +53,7 @@ func (sess *Session) Start(ctx context.Context) error {
 	backendSession := sess.backend.CreateSession(sess)
 	defer backendSession.Close()
 
+	auth := backendSession.Authentication()
 	vfs := backendSession.GetFS()
 	stat := backendSession.GetStatService()
 
@@ -96,6 +97,7 @@ func (sess *Session) Start(ctx context.Context) error {
 			mux = &Muxv4{
 				reader: reader,
 				writer: writer,
+				auth:   auth,
 				fs:     vfs,
 				stat:   stat,
 			}
@@ -104,6 +106,7 @@ func (sess *Session) Start(ctx context.Context) error {
 			mux = &Mux{
 				reader: reader,
 				writer: writer,
+				auth:   auth,
 				fs:     vfs,
 				stat:   stat,
 			}

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -40,6 +40,8 @@ func New(workdir string) (*UnixFS, error) {
 	}, nil
 }
 
+func (s *UnixFS) SetCreds(creds fs.Creds) {}
+
 func (s *UnixFS) Attributes() *fs.Attributes {
 	return &s.attributes
 }


### PR DESCRIPTION
Hello, first of all: good job! I'm trying to integrate this project to export a virtual file system as NFS. Being virtual, the displayed posix permissions don't necessarily match with the actual permissions a user has (i.e. which actions the user can do successfully). To handle this properly, I would like to retrieve the uid of a connecting user, so in listing files, it can appear that that user owns all files; and if the user tries to read/change anything, I can put custom enforcements based on his identity.

For this, I implemented AUTH_UNIX = AUTH_SYS, and I pass the current credentials to the new SetCreds function in the fs.FS interface. Since the SetCreds and the other FS functions should not interleave for different sessions, I now create a new FS for each connection in the provided backend. 

I'm not entirely happy with the introduction of the SetCreds function, but it was currently the fastest way to pass this information. Alternatively, credentials could passed as argument to all FS' functions, or one could somehow create a new FS for each newly authenticated user and cache it.