### PR TITLE
Add maxread and maxwrite attributes to filesystems

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -84,5 +84,7 @@ type Attributes struct {
 	SymlinkSupport  bool   // id: 6
 	ChownRestricted bool   // id: 18
 	MaxName         uint32 // id: 29
+	MaxRead         uint64 // id: 30
+	MaxWrite        uint64 // id: 31
 	NoTrunc         bool   // id: 34
 }

--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -137,9 +137,11 @@ func NewMemFS() *MemFS {
 		},
 		attributes: fs.Attributes{
 			LinkSupport:     true,
-			SymlinkSupport:  false, // unsopported
-			ChownRestricted: true,  // unsopported
-			MaxName:         255,   // common value
+			SymlinkSupport:  false,   // unsopported
+			ChownRestricted: true,    // unsopported
+			MaxName:         255,     // common value
+			MaxRead:         1048576, // common value
+			MaxWrite:        1048576, // common value
 			NoTrunc:         false,
 		},
 	}

--- a/nfs/implv4/attrs.go
+++ b/nfs/implv4/attrs.go
@@ -34,6 +34,8 @@ const (
 	A_filehandle         = 19 // nfs_fh4, opaque<>
 	A_fileid             = 20 // uint64
 	A_maxname            = 29 // uint32
+	A_maxread            = 30 // uint32
+	A_maxwrite           = 31 // uint32
 	A_mode               = 33 // (v4.1) uint32
 	A_no_trunc           = 34 // bool
 	A_numlinks           = 35 // uint32
@@ -95,6 +97,8 @@ var (
 		A_filehandle,
 		A_fileid,
 		A_maxname,
+		A_maxread,
+		A_maxwrite,
 		A_mode,
 		A_no_trunc,
 		A_numlinks,
@@ -155,6 +159,10 @@ func GetAttrNameById(id int) (string, bool) {
 		return "fileid", true
 	case A_maxname:
 		return "maxname", true
+	case A_maxread:
+		return "maxread", true
+	case A_maxwrite:
+		return "maxwrite", true
 	case A_mode:
 		return "mode", true
 	case A_no_trunc:
@@ -223,6 +231,8 @@ func getAttrsMaxBytesSize(req map[int]bool) uint32 {
 		A_filehandle:        128 + 4, // max value
 		A_fileid:            8,
 		A_maxname:           4,
+		A_maxread:           8,
+		A_maxwrite:          8,
 		A_mode:              4,
 		A_no_trunc:          4,
 		A_numlinks:          4,
@@ -414,6 +424,12 @@ func fileInfoToAttrs(vfs fs.FS, pathName string, fi fs.FileInfo, attrsRequest ma
 
 		case A_maxname:
 			writeAny(a, attrsFS.MaxName, 4)
+
+		case A_maxread:
+			writeAny(a, attrsFS.MaxRead, 8)
+
+		case A_maxwrite:
+			writeAny(a, attrsFS.MaxWrite, 8)
 
 		case A_mode:
 			mask := (uint32(1) << 9) - 1

--- a/nfs/implv4/rename.go
+++ b/nfs/implv4/rename.go
@@ -11,7 +11,7 @@ import (
 )
 
 func rename(x nfs.RPCContext, args *nfs.RENAME4args) (*nfs.RENAME4res, error) {
-	log.Debugf("remame obj: %s -> %s", strconv.Quote(args.OldName), strconv.Quote(args.NewName))
+	log.Infof("remame obj: %s -> %s", strconv.Quote(args.OldName), strconv.Quote(args.NewName))
 
 	stat := x.Stat()
 	vfs := x.GetFS()

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -33,9 +33,11 @@ func New(workdir string) (*UnixFS, error) {
 		attributes: fs.Attributes{
 			LinkSupport:     true,
 			SymlinkSupport:  true,
-			ChownRestricted: true,  // Supported but chown is disabled by default for security reason
-			MaxName:         255,   // Common value
-			NoTrunc:         false, // Safe value
+			ChownRestricted: true,    // Supported but chown is disabled by default for security reason
+			MaxName:         255,     // Common value
+			MaxRead:         1048576, // common value
+			MaxWrite:        1048576, // common value
+			NoTrunc:         false,   // Safe value
 		},
 	}, nil
 }


### PR DESCRIPTION
Hi! Thanks for this project, it looks great! I was testing locally and did some profiling. I noticed with larger files on memory-constrained systems I was seeing some fluctuation in throughput. A transfer would start fast and then slow down after hitting about 500MB, a number which number turned out to be related to filesystem caching on the client. The host running `libnfs-go` was also hitting 100% cpu. I isolated the slowdown with `dd` and the `sync` `oflag` down to the following test case which reproduces immediately:
```
sudo dd if=/dev/urandom of=/mnt/urandom oflag=sync bs=10M status=progress
```
Initially, I was only getting between 1 and 4 MBps. The results seemed relatively the same for the unixfs and memfs. I did some go profiling and investigating, and finally noticed that the maxwrite and maxread were 1024 on my nfs mount:
```
mounthost:/ on /mnt type nfs4 (rw,relatime,vers=4.0,rsize=1024,wsize=1024,namlen=255,hard,proto=tcp,port=2050,timeo=600,retrans=2,sec=sys,clientaddr=clienthost,local_lock=none,addr=mounthost
```

I made the included changes to enable `maxread` and `maxwrite` attributes as mentioned in the RFC. I basically did a copy-paste job for the existing `maxname` attribute. After these changes, I can get my client to negotiate `rsize=1048576,wsize=1048576`,  and the same `dd` test case above yields 40MB/s, which is close enough to what I would expect for my network environment.

My client: `Linux localhost 6.1.85-flatcar #1 SMP PREEMPT_DYNAMIC Sat Apr 13 13:03:01 -00 2024 x86_64 AMD G-T48E Processor AuthenticAMD GNU/Linux`

I would be interested to know if you've done any profiling, and if so what kind of results you are getting.