### PR TITLE
fix: implement proper chown support in memfs

### DIFF
--- a/memfs/file_info.go
+++ b/memfs/file_info.go
@@ -9,6 +9,8 @@ type fileInfo struct {
 	id       uint64
 	name     string
 	perm     os.FileMode
+	uid      uint32
+	gid      uint32
 	size     int64
 	modTime  time.Time
 	aTime    time.Time
@@ -51,4 +53,12 @@ func (fi fileInfo) Sys() interface{} {
 
 func (fi fileInfo) NumLinks() int {
 	return fi.numLinks
+}
+
+func (fi fileInfo) Uid() uint32 {
+	return fi.uid
+}
+
+func (fi fileInfo) Gid() uint32 {
+	return fi.gid
 }

--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -24,6 +24,8 @@ type memFsNode struct {
 	isDir    bool
 	nodeId   uint64 // storage data-node id
 	perm     os.FileMode
+	uid      int
+	gid      int
 	aTime    time.Time
 	cTime    time.Time
 	mTime    time.Time
@@ -137,8 +139,8 @@ func NewMemFS() *MemFS {
 		},
 		attributes: fs.Attributes{
 			LinkSupport:     true,
-			SymlinkSupport:  false,   // unsopported
-			ChownRestricted: true,    // unsopported
+			SymlinkSupport:  false,   // unsupported
+			ChownRestricted: false,   // allow chown in memfs
 			MaxName:         255,     // common value
 			MaxRead:         1048576, // common value
 			MaxWrite:        1048576, // common value
@@ -171,6 +173,8 @@ func (s *MemFS) getFileInfo(n *memFsNode) *fileInfo {
 		id:       n.id,
 		name:     path.Base(n.name),
 		perm:     n.perm,
+		uid:      uint32(n.uid),
+		gid:      uint32(n.gid),
 		size:     n.size,
 		modTime:  n.mTime,
 		aTime:    n.aTime,
@@ -477,7 +481,15 @@ func (s *MemFS) ResolveHandle(fh []byte) (string, error) {
 }
 
 func (s *MemFS) Chown(name string, uid, gid int) error {
-	log.Warn("TODO: memfs.Chown not implemented")
+	s.lck.Lock()
+	defer s.lck.Unlock()
+
+	node, found := s.getNode(name)
+	if !found {
+		return os.ErrNotExist
+	}
+	node.uid = uid
+	node.gid = gid
 	return nil
 }
 


### PR DESCRIPTION
- Add uid/gid fields to memFsNode struct
- Add uid/gid fields to fileInfo struct with Uid()/Gid() methods
- Set ChownRestricted to false to allow chown operations
- Implement Chown() to actually store uid/gid values

This fixes rsync errors like 'chgrp failed: Operation not permitted'